### PR TITLE
Fix GitHub Actions deployment workflow authentication

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,8 +28,7 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
-          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2


### PR DESCRIPTION
## Fix GitHub Actions Deployment Workflow

This PR fixes the GitHub Actions deployment workflow that was failing due to missing Workload Identity Federation (WIF) secrets.

### Changes Made
- Updated the Google Auth step to use the available `GCP_SA_KEY` secret instead of the missing WIF secrets

### Testing
After merging, the deployment workflow should successfully authenticate with Google Cloud.

Fixes #20