### PR TITLE
Fix #23: Add missing tags to tags.yml

### DIFF
--- a/blog/tags.yml
+++ b/blog/tags.yml
@@ -17,3 +17,33 @@ hola:
   label: Hola
   permalink: /hola
   description: Hola tag description
+
+ai:
+  label: AI
+  permalink: /ai
+  description: Artificial Intelligence related content
+
+coding:
+  label: Coding
+  permalink: /coding
+  description: Content related to coding practices and techniques
+
+programming:
+  label: Programming
+  permalink: /programming
+  description: Programming concepts, languages, and methodologies
+
+development:
+  label: Development
+  permalink: /development
+  description: Software development processes and tools
+
+tools:
+  label: Tools
+  permalink: /tools
+  description: Software tools and utilities for developers
+
+case-study:
+  label: Case Study
+  permalink: /case-study
+  description: Real-world examples and case studies


### PR DESCRIPTION
## Add missing tags to tags.yml

This PR adds the missing tags to the `blog/tags.yml` file to resolve build warnings.

### Changes Made
Added the following tags to `blog/tags.yml`:
- `ai`
- `coding`
- `programming`
- `development`
- `tools`
- `case-study`

Each tag includes:
- A proper label
- A permalink
- A description

### Testing
- Built the project locally to verify that the warnings no longer appear
- Confirmed that the blog post tags are properly linked

Fixes #23