### PR TITLE
Fix #25: Add Husky pre-commit hook to ensure project builds

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+echo "Running pre-commit checks..."
+npm run pre-commit-check

--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ We welcome contributions to improve the documentation:
 5. Push to the branch (`git push origin feature/amazing-improvement`)
 6. Open a Pull Request
 
+### Pre-commit Hooks
+
+This repository uses Husky to run pre-commit hooks that ensure code quality. When you commit changes, the following checks will run automatically:
+
+- Building the project to ensure there are no build errors or warnings
+
+If the build fails, your commit will be aborted. Fix the issues and try committing again.
+
+To manually run the checks:
+
+```bash
+npm run pre-commit-check
+```
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "prepare": "husky",
+    "pre-commit-check": "npm run build"
   },
   "dependencies": {
     "@docusaurus/core": "3.7.0",
@@ -33,6 +35,8 @@
     "@typescript-eslint/parser": "^7.0.0",
     "eslint": "^8.56.0",
     "eslint-plugin-react": "^7.33.2",
+    "husky": "^9.1.7",
+    "lint-staged": "^15.4.3",
     "typescript": "~5.6.2"
   },
   "browserslist": {
@@ -49,5 +53,10 @@
   },
   "engines": {
     "node": ">=18.0"
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --fix"
+    ]
   }
 }


### PR DESCRIPTION
## Add Husky pre-commit hook to ensure project builds

This PR implements a pre-commit hook using Husky that runs the build process before allowing commits. This ensures that build warnings and errors are caught early in the development process.

### Changes Made
- Added Husky and lint-staged as dev dependencies
- Configured a pre-commit hook that runs `npm run build`
- Added a `pre-commit-check` script to package.json
- Updated README.md with information about the pre-commit hook

### Testing
- Verified that the pre-commit hook runs correctly when committing changes
- Confirmed that the build process runs during the pre-commit hook

### Notes
- When this PR is merged, it will work together with PR #24 to prevent future tag-related warnings
- The pre-commit hook will prevent commits if the build fails, ensuring code quality

Fixes #25