### PR TITLE
Improve sidebar navigation category titles

### DIFF
--- a/docs/getting-started/_category_.json
+++ b/docs/getting-started/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Getting Started",
+  "position": 2,
+  "link": {
+    "type": "generated-index",
+    "description": "Getting started with MyCoder installation and setup"
+  }
+}

--- a/docs/usage/_category_.json
+++ b/docs/usage/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Usage Guide",
+  "position": 3,
+  "link": {
+    "type": "generated-index",
+    "description": "Learn how to use MyCoder effectively"
+  }
+}


### PR DESCRIPTION
## Improve Sidebar Navigation Category Titles

This PR addresses issue #34 by adding `_category_.json` files to customize the display names of sidebar categories.

### Changes Made

- Added `_category_.json` to the `getting-started` directory with a proper "Getting Started" label
- Added `_category_.json` to the `usage` directory with a proper "Usage Guide" label
- Set appropriate positions and added descriptive text for each category

### Before / After

**Before:**
- Categories displayed as lowercase, hyphenated directory names: "getting-started" and "usage"

**After:**
- Categories now display as proper titles: "Getting Started" and "Usage Guide"

### Testing Done

- Built the site locally and verified that the sidebar displays the correct category names
- Ensured navigation structure remains intact

This simple approach maintains the existing directory structure while providing a more professional appearance in the navigation.