### PR TITLE
Fix sidebar categories to eliminate duplicate entries

### DIFF
--- a/docs/getting-started/_category_.json
+++ b/docs/getting-started/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Getting Started",
+  "position": 2,
+  "link": {
+    "type": "doc",
+    "id": "getting-started"
+  }
+}

--- a/docs/usage/_category_.json
+++ b/docs/usage/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Usage Guide",
+  "position": 3,
+  "link": {
+    "type": "doc",
+    "id": "usage"
+  }
+}


### PR DESCRIPTION
## Improve Sidebar Navigation and Eliminate Duplicate Entries

This PR addresses issue #34 by adding `_category_.json` files with a specialized configuration that eliminates duplicate entries in the sidebar navigation.

### Problem Solved

Previously, we had duplicate entries in the navigation:
- Both a standalone "Getting Started" page and a "getting-started" category
- Both a standalone "Usage" page and a "usage" category

### Solution Implemented

- Added `_category_.json` files to customize category display names
- Configured categories to use the main pages as their index pages instead of auto-generated indexes
- This makes the main pages serve as both category entries and content pages

### Changes Made

1. Added `_category_.json` to the `getting-started` directory:
   ```json
   {
     "label": "Getting Started",
     "position": 2,
     "link": {
       "type": "doc",
       "id": "getting-started"
     }
   }
   ```

2. Added `_category_.json` to the `usage` directory:
   ```json
   {
     "label": "Usage Guide",
     "position": 3,
     "link": {
       "type": "doc",
       "id": "usage"
     }
   }
   ```

### Before / After

**Before:**
- Duplicate entries in sidebar
- Categories displayed as lowercase, hyphenated directory names

**After:**
- Clean navigation with proper category labels
- No duplicate entries
- Main pages serve as both category entries and content pages

This approach maintains the existing directory structure and content organization while providing a more professional and user-friendly navigation experience.