### PR TITLE
Update link styling: darker gray-blue color and remove default underline

### DIFF
--- a/docs/getting-started/_category_.json
+++ b/docs/getting-started/_category_.json
@@ -3,6 +3,6 @@
   "position": 2,
   "link": {
     "type": "doc",
-    "id": "getting-started"
+    "id": "getting-started/index"
   }
 }

--- a/docs/usage/_category_.json
+++ b/docs/usage/_category_.json
@@ -3,6 +3,6 @@
   "position": 3,
   "link": {
     "type": "doc",
-    "id": "usage"
+    "id": "usage/index"
   }
 }

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -113,12 +113,12 @@ const config: Config = {
           label: 'Documentation',
         },
         {
-          to: '/docs/getting-started',
+          to: '/docs/getting-started/',
           label: 'Getting Started',
           position: 'left',
         },
         {
-          to: '/docs/usage',
+          to: '/docs/usage/',
           label: 'Usage',
           position: 'left'
         },

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -15,7 +15,7 @@
   --ifm-color-primary-lightest: #0e85ff;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
-  --ifm-link-color: #0066cc;
-  --ifm-link-hover-color: #0057ad;
-  --ifm-link-decoration: underline;
+  --ifm-link-color: #3a5978; /* Darker gray-blue */
+  --ifm-link-hover-color: #2c4359; /* Even darker on hover */
+  --ifm-link-decoration: none; /* Remove default underline */
 }


### PR DESCRIPTION
## Update Link Styling: Darker Gray-Blue Color and Remove Default Underline

This PR updates the link styling in the documentation site:

1. Changed the link color to a darker gray-blue shade (#3a5978)
2. Removed the default underline from links (they will still underline on hover)

### Changes Made
- Updated CSS variables in `src/css/custom.css`:
  - Modified `--ifm-link-color` to #3a5978 (darker gray-blue)
  - Modified `--ifm-link-hover-color` to #2c4359 (darker version for hover)
  - Changed `--ifm-link-decoration` from `underline` to `none`

### Build Fixes
Also fixed several build issues with document IDs and navigation links:
- Updated document IDs in category configuration files
- Fixed navigation links in the navbar to use the correct URL format

### Visual Changes
Links will now appear in a darker gray-blue color without underlines by default, creating a cleaner and more professional look. Links will still underline on hover to maintain accessibility and user experience.

Closes #42