### PR TITLE
Update top navigation: rename Documentation to Intro and add Examples

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -109,7 +109,7 @@ const config: Config = {
           type: 'docSidebar',
           sidebarId: 'tutorialSidebar',
           position: 'left',
-          label: 'Documentation',
+          label: 'Intro',
         },
         {
           to: '/docs/getting-started/',
@@ -119,6 +119,11 @@ const config: Config = {
         {
           to: '/docs/usage/',
           label: 'Usage',
+          position: 'left'
+        },
+        {
+          to: '/docs/examples/',
+          label: 'Examples',
           position: 'left'
         },
         {to: '/blog', label: 'Blog', position: 'left'},


### PR DESCRIPTION
# Update Top Navigation

This PR updates the top navigation bar to:

1. Rename "Documentation" to "Intro" for a more concise label
2. Add "Examples" as a top-level navigation item

## Changes

- Modified `docusaurus.config.ts` to update the navigation items
- Kept the same order of navigation items, adding Examples before Blog
- Preserved all other navigation settings and functionality

## Purpose

These changes make the Examples section more discoverable by adding it to the top navigation, and make the "Documentation" label shorter and more to the point by renaming it to "Intro".

## Testing

The build completes successfully, and the navigation bar displays the updated items correctly.